### PR TITLE
Contributors box flexwrap and word-break for `li` and `p` elements 

### DIFF
--- a/src/components/page-footer.js
+++ b/src/components/page-footer.js
@@ -31,7 +31,7 @@ const Contributors = ({contributors = [], latestCommit}) => {
 
   return (
     <>
-      <Box sx={{display: 'flex', alignItems: 'center'}}>
+      <Box sx={{display: 'flex', alignItems: 'center', flexWrap: 'wrap'}}>
         <Text sx={{mr: 2}}>
           {contributors.length} {pluralize('contributor', contributors.length)}
         </Text>

--- a/src/mdx/components.js
+++ b/src/mdx/components.js
@@ -179,7 +179,7 @@ export const UnorderedList = styled.ul`
   }
 
   li {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   li > p {
@@ -195,6 +195,7 @@ export const OrderedList = UnorderedList.withComponent('ol')
 
 export const Paragraph = styled.p`
   margin: 0 0 ${themeGet('space.3')};
+  word-break: break-word;
 `
 
 export const Table = styled.table`


### PR DESCRIPTION
Addressing [Issue 1348](https://github.com/npm/documentation/issues/1348)